### PR TITLE
Update for Rails < 6

### DIFF
--- a/flag-icons-rails.gemspec
+++ b/flag-icons-rails.gemspec
@@ -18,11 +18,10 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.required_ruby_version = '>= 2.0'
 
-  s.add_runtime_dependency 'sass', '~> 3.2'
+  s.add_runtime_dependency 'sass-rails'
 
   s.add_development_dependency 'railties', '>= 3.2', '< 6'
   s.add_development_dependency 'activesupport'
-  s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'minitest', '~> 5.10.0'
   s.add_development_dependency 'minitest-have_tag', '~> 0.1.0'

--- a/flag-icons-rails.gemspec
+++ b/flag-icons-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'sass', '~> 3.2'
 
-  s.add_development_dependency 'railties', '>= 3.2', '< 5.1'
+  s.add_development_dependency 'railties', '>= 3.2', '< 6'
   s.add_development_dependency 'activesupport'
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'pry'

--- a/test/dummy/app/assets/config/manifest.js
+++ b/test/dummy/app/assets/config/manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css


### PR DESCRIPTION
To support Rails versions up to 5.x, add dummy manifest and replace `sass` gem requirement with `sass-rails` which itself is in transition to move from sass to sassc.

Sidenote for the future:
Later addition of Rails 6 support may be a good point to drop support for Rails < 5 and update both ruby version requirement and test gems. This version should be compatible to Rails 6 though.